### PR TITLE
Fix a security issue with the cert provided in a gcc packet

### DIFF
--- a/core/RDP/gcc.hpp
+++ b/core/RDP/gcc.hpp
@@ -2547,6 +2547,12 @@ namespace GCC
                 }
                 else {
                     this->x509.certCount = stream.in_uint32_le();
+                    if (this->x509.certCount > 32){
+			LOG(LOG_ERR, "More than 32 certificates (count=%u), this is probably an attack", 
+				this->x509.certCount);
+                        throw Error(ERR_GCC);                    
+                    }
+                    
                     for (size_t i = 0; i < this->x509.certCount ; i++){
                         this->x509.cert[i].len = stream.in_uint32_le();
                         this->x509.cert[i].cert = d2i_X509(NULL, const_cast<const uint8_t **>(&stream.p), this->x509.cert[i].len);


### PR DESCRIPTION
This patch ensure that a gcc packet does not contain more than 32 certificates as it's the size array that will store them. Most probably having more than 32 certificates means that it's an attack.

As exercise, 3 lines later before calling d2i_X509() the remaining bytes in the stream should be checked.

No sure a CVE is needed for that fix.
