### PR TITLE
TestTransport class can now take input and outputnnames without lengths ...

### DIFF
--- a/tests/transport/test_test_transport.cpp
+++ b/tests/transport/test_test_transport.cpp
@@ -174,6 +174,38 @@ BOOST_AUTO_TEST_CASE(TestTestTransport)
     BOOST_CHECK(!gt.get_status());
 }
 
+
+BOOST_AUTO_TEST_CASE(TestTestTransport2)
+{
+    /*!
+        Please see Notes from above test case
+        The below is exactly the same except the class TestTransport is instantiated
+        differently such that it invokes a different constructor that takes the
+        input and output names (and not their sizes unlike the other constructor) into account
+     */
+    TestTransport gt("Test1", "OUTPUT","input");
+    /*
+    Everything that follows in this test case is same as in "BOOST_AUTO_TEST_CASE(TestTestTransport)" above
+    */
+    BOOST_CHECK_EQUAL(gt.get_status(), true);
+    char buf[128] = {};
+    char * p = buf;
+    uint32_t sz = 3;
+    gt.recv(&p, sz);
+    BOOST_CHECK(0 == memcmp(p - sz, "OUT", sz));
+    gt.send("in", 2);
+    BOOST_CHECK_EQUAL(gt.get_status(), true);
+    sz = 3;
+    gt.recv(&p, sz);
+    BOOST_CHECK(0 == memcmp(p - sz, "PUT", sz));
+    try {
+        gt.send("pot", 3);
+    } catch (const Error & e){
+        BOOST_CHECK_EQUAL((uint16_t)ERR_TRANSPORT_DIFFERS, (uint16_t)e.id);
+    };
+    BOOST_CHECK(!gt.get_status());
+}
+
 BOOST_AUTO_TEST_CASE(TestMemoryTransport)
 {
     MemoryTransport mt;

--- a/transport/test_transport.hpp
+++ b/transport/test_transport.hpp
@@ -115,6 +115,13 @@ public:
     , public_key_length(0)
     {}
 
+    // Introducing a new constructor with only the input and outout filenames
+    TestTransport(const char * name, const std::string& outdata, const std::string& indata, uint32_t verbose = 0)
+    : check(indata.c_str(), indata.length(), verbose)
+    , gen(outdata.c_str(), outdata.length(), verbose)
+    , public_key_length(0)
+    {}
+
     void set_public_key(const uint8_t * data, size_t data_size) {
         this->public_key.reset(new uint8_t[data_size]);
         this->public_key_length = data_size;


### PR DESCRIPTION
...which are now computed automatically. Corresponding test case added