### PR TITLE
vnc: add support VeNCrypt authentication

### DIFF
--- a/projects/ClientQtGraphicAPI/src/qt_input_output_api/qt_graphics_components/qt_form_window.hpp
+++ b/projects/ClientQtGraphicAPI/src/qt_input_output_api/qt_graphics_components/qt_form_window.hpp
@@ -416,8 +416,6 @@ public:
         this->line_edit_layout.addRow(&(this->_portLabel)    , &(this->_portField));
 
         if (this->protocol_type == ClientRedemptionConfig::MOD_VNC) {
-            this->_userNameField.hide();
-            this->_userNameLabel.hide();
             this->_portField.setText("5900");
         } else  {
             this->_portField.setText("3389");


### PR DESCRIPTION
This PR adds support for VeNCrypt authentication with the X509 subtypes. It supports None, VNC and plain authentication on top of X509.