### PR TITLE
Fix test_config from projects/redemption_configs

### DIFF
--- a/projects/redemption_configs/tests/test_config.cpp
+++ b/projects/redemption_configs/tests/test_config.cpp
@@ -265,9 +265,6 @@ RED_AUTO_TEST_CASE(TestConfigDefaultEmpty)
 
     RED_CHECK_EQUAL("",                               ini.get<cfg::context::rejected>());
 
-    RED_CHECK_EQUAL(false,                            ini.get<cfg::context::authenticated>());
-
-
     RED_CHECK_EQUAL(false,                            ini.is_asked<cfg::context::keepalive>());
 
     RED_CHECK_EQUAL(false,                            ini.get<cfg::context::keepalive>());


### PR DESCRIPTION
I faced a test compilation failure while rebuilding redemption_configs project for up-porting correction of issue #27767 to maintenance_8.1.

I just removed the check.

Please confirm that it is safe to do so.