### PR TITLE
refs #27767: allow the client build number to be transferred to the server (up-port to 8.1)

### DIFF
--- a/projects/redemption_configs/autogen/doc/sesman_dialog.txt
+++ b/projects/redemption_configs/autogen/doc/sesman_dialog.txt
@@ -237,6 +237,8 @@ cfg::mod_rdp::mode_console ⇐ mod_rdp:mode_console   [RdpModeConsole]
       force: Force Console mode on target regardless of client request.
       forbid: Block Console mode request from client.
 cfg::mod_rdp::auto_reconnection_on_losing_target_link ⇐ mod_rdp:auto_reconnection_on_losing_target_link   [bool]
+cfg::mod_rdp::forward_client_build_number ⇐ mod_rdp:forward_client_build_number   [bool]
+    Forward the build number advertised by the client to the server. If forwarding is disabled a default (static) build number will be sent to the server.
 
 cfg::mod_vnc::clipboard_up ⇐ clipboard_up   [bool]
     Enable or disable the clipboard from client (client to server).

--- a/projects/redemption_configs/autogen/include/configs/autogen/authid.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/authid.hpp
@@ -7,5 +7,5 @@
 namespace configs
 {
     enum class authid_t : unsigned;
-    constexpr authid_t max_authid = authid_t(206);
+    constexpr authid_t max_authid = authid_t(207);
 }

--- a/projects/redemption_configs/autogen/include/configs/autogen/cp_mapping.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/cp_mapping.hpp
@@ -82,6 +82,9 @@ cp_spec = {
         u'mod_rdp:auto_reconnection_on_losing_target_link': (
             'auto_reconnection_on_losing_target_link', False
         ),
+        u'mod_rdp:forward_client_build_number': (
+            'forward_client_build_number', True
+        ),
         u'context:rail_disconnect_message_delay': (
             'remote_programs_disconnect_message_delay', 3000
         ),

--- a/projects/redemption_configs/autogen/include/configs/autogen/rdp_cp_spec.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/rdp_cp_spec.hpp
@@ -130,6 +130,10 @@ mode_console = option('allow', 'force', 'forbid', default='allow')
 #_advanced
 auto_reconnection_on_losing_target_link = boolean(default=False)
 
+# Forward the build number advertised by the client to the server. If forwarding is disabled a default (static) build number will be sent to the server.
+#_advanced
+forward_client_build_number = boolean(default=True)
+
 # Delay before showing disconnect message after the last RemoteApp window is closed.
 # (is in millisecond)
 #_advanced

--- a/projects/redemption_configs/autogen/include/configs/autogen/set_value.tcc
+++ b/projects/redemption_configs/autogen/include/configs/autogen/set_value.tcc
@@ -1420,6 +1420,14 @@ void Inifile::ConfigurationHolder::set_value(zstring_view key, zstring_view valu
                 value
             );
         }
+        else if (key == "forward_client_build_number"_zv) {
+            ::config_parse_and_log(
+                this->section_name, key.c_str(),
+                static_cast<cfg::mod_rdp::forward_client_build_number&>(this->variables).value,
+                ::configs::spec_type<bool>{},
+                value
+            );
+        }
 
         else if (static_cast<cfg::debug::config>(this->variables).value) {
             LOG(LOG_WARNING, "unknown parameter %s in section [%s]",

--- a/projects/redemption_configs/autogen/include/configs/autogen/str_authid.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/str_authid.hpp
@@ -104,6 +104,7 @@ namespace configs
         "mod_rdp:enable_ipv6"_zv,
         "mod_rdp:mode_console"_zv,
         "mod_rdp:auto_reconnection_on_losing_target_link"_zv,
+        "mod_rdp:forward_client_build_number"_zv,
         "clipboard_up"_zv,
         "clipboard_down"_zv,
         "vnc_server_clipboard_encoding_type"_zv,

--- a/projects/redemption_configs/autogen/include/configs/autogen/str_ini.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/str_ini.hpp
@@ -880,6 +880,11 @@ R"gen_config_ini(## Config file for RDP proxy.
 #_hidden
 #auto_reconnection_on_losing_target_link = 0
 
+# Forward the build number advertised by the client to the server. If forwarding is disabled a default (static) build number will be sent to the server.
+# value: 0 or 1
+#_hidden
+#forward_client_build_number = 1
+
 [mod_vnc]
 
 # Enable or disable the clipboard from client (client to server).

--- a/projects/redemption_configs/autogen/include/configs/autogen/str_python_spec.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/str_python_spec.hpp
@@ -746,6 +746,10 @@ enable_ipv6 = boolean(default=False)
 #_hidden
 auto_reconnection_on_losing_target_link = boolean(default=False)
 
+# Forward the build number advertised by the client to the server. If forwarding is disabled a default (static) build number will be sent to the server.
+#_hidden
+forward_client_build_number = boolean(default=True)
+
 [mod_vnc]
 
 # Enable or disable the clipboard from client (client to server).

--- a/projects/redemption_configs/autogen/include/configs/autogen/variables_configuration.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/variables_configuration.hpp
@@ -15,24 +15,24 @@ namespace configs
         inline constexpr int section1 = 19; /* session_log */
         inline constexpr int section2 = 20; /* client */
         inline constexpr int section3 = 22; /* mod_rdp */
-        inline constexpr int section4 = 94; /* mod_vnc */
-        // inline constexpr int section5 = 102; /* metrics */
-        inline constexpr int section6 = 102; /* file_verification */
-        inline constexpr int section7 = 110; /* file_storage */
-        // inline constexpr int section8 = 111; /* icap_server_down */
-        // inline constexpr int section9 = 111; /* icap_server_up */
-        inline constexpr int section10 = 111; /* mod_replay */
-        // inline constexpr int section11 = 112; /* ocr */
-        inline constexpr int section12 = 112; /* video */
-        inline constexpr int section13 = 117; /* capture */
-        inline constexpr int section14 = 120; /* crypto */
-        // inline constexpr int section15 = 122; /* websocket */
-        // inline constexpr int section16 = 122; /* debug */
-        inline constexpr int section17 = 122; /* remote_program */
-        inline constexpr int section18 = 123; /* translation */
-        // inline constexpr int section19 = 126; /* internal_mod */
-        inline constexpr int section20 = 126; /* context */
-        // inline constexpr int section21 = 206; /* theme */
+        inline constexpr int section4 = 95; /* mod_vnc */
+        // inline constexpr int section5 = 103; /* metrics */
+        inline constexpr int section6 = 103; /* file_verification */
+        inline constexpr int section7 = 111; /* file_storage */
+        // inline constexpr int section8 = 112; /* icap_server_down */
+        // inline constexpr int section9 = 112; /* icap_server_up */
+        inline constexpr int section10 = 112; /* mod_replay */
+        // inline constexpr int section11 = 113; /* ocr */
+        inline constexpr int section12 = 113; /* video */
+        inline constexpr int section13 = 118; /* capture */
+        inline constexpr int section14 = 121; /* crypto */
+        // inline constexpr int section15 = 123; /* websocket */
+        // inline constexpr int section16 = 123; /* debug */
+        inline constexpr int section17 = 123; /* remote_program */
+        inline constexpr int section18 = 124; /* translation */
+        // inline constexpr int section19 = 127; /* internal_mod */
+        inline constexpr int section20 = 127; /* context */
+        // inline constexpr int section21 = 207; /* theme */
     }
 }
 
@@ -2545,6 +2545,22 @@ namespace cfg
         using sesman_and_spec_type = bool;
         using mapped_type = sesman_and_spec_type;
         type value{false};
+    };
+    /// Forward the build number advertised by the client to the server. If forwarding is disabled a default (static) build number will be sent to the server. <br/>
+    /// type: bool <br/>
+    /// connpolicy -> proxy <br/>
+    /// sesmanName: mod_rdp:forward_client_build_number <br/>
+    /// default: {true} <br/>
+    struct mod_rdp::forward_client_build_number {
+        static constexpr bool is_sesman_to_proxy = true;
+        static constexpr bool is_proxy_to_sesman = false;
+        // for old cppcheck
+        // cppcheck-suppress obsoleteFunctionsindex
+        static constexpr ::configs::authid_t index { ::configs::cfg_indexes::section3 + 72};
+        using type = bool;
+        using sesman_and_spec_type = bool;
+        using mapped_type = sesman_and_spec_type;
+        type value{true};
     };
 
     /// Enable or disable the clipboard from client (client to server). <br/>
@@ -5443,6 +5459,7 @@ struct mod_rdp
 , cfg::mod_rdp::enable_ipv6
 , cfg::mod_rdp::mode_console
 , cfg::mod_rdp::auto_reconnection_on_losing_target_link
+, cfg::mod_rdp::forward_client_build_number
 { static constexpr bool is_section = true; };
 
 struct mod_vnc
@@ -5835,6 +5852,7 @@ using VariablesAclPack = Pack<
 , cfg::mod_rdp::enable_ipv6
 , cfg::mod_rdp::mode_console
 , cfg::mod_rdp::auto_reconnection_on_losing_target_link
+, cfg::mod_rdp::forward_client_build_number
 , cfg::mod_vnc::clipboard_up
 , cfg::mod_vnc::clipboard_down
 , cfg::mod_vnc::server_clipboard_encoding_type
@@ -5957,14 +5975,14 @@ struct BitFlags {
 
 constexpr BitFlags is_loggable{{
   0b1111111111111111111111111111111111111111111111111101111111111111
-, 0b1111110011111111111111111111111111111111111111111111111111111111
-, 0b1101111111111111111111111111111111111111111110110111110111111111
-, 0b0000000000000000000000000000000000000000000000000011111111111111
+, 0b1111100111111111111111111111111111111111111111111111111111111111
+, 0b1011111111111111111111111111111111111111111101101111101111111111
+, 0b0000000000000000000000000000000000000000000000000111111111111111
 }};
 constexpr BitFlags is_unloggable_if_value_with_password{{
   0b0000000000000000000000000000000000000000000000000000000000000000
 , 0b0000000000000000000000000000000000000000000000000000000000000000
-, 0b0000000000000000000000000000000000000000000001000000000000000000
+, 0b0000000000000000000000000000000000000000000010000000000000000000
 , 0b0000000000000000000000000000000000000000000000000000000000000000
 }};
 } // namespace configs

--- a/projects/redemption_configs/autogen/include/configs/autogen/variables_configuration_fwd.hpp
+++ b/projects/redemption_configs/autogen/include/configs/autogen/variables_configuration_fwd.hpp
@@ -208,6 +208,7 @@ namespace cfg
         struct enable_ipv6;
         struct mode_console;
         struct auto_reconnection_on_losing_target_link;
+        struct forward_client_build_number;
     };
 
     struct mod_vnc {

--- a/projects/redemption_configs/autogen/spec/rdp.spec
+++ b/projects/redemption_configs/autogen/spec/rdp.spec
@@ -126,6 +126,10 @@ mode_console = option('allow', 'force', 'forbid', default='allow')
 #_advanced
 auto_reconnection_on_losing_target_link = boolean(default=False)
 
+# Forward the build number advertised by the client to the server. If forwarding is disabled a default (static) build number will be sent to the server.
+#_advanced
+forward_client_build_number = boolean(default=True)
+
 # Delay before showing disconnect message after the last RemoteApp window is closed.
 # (is in millisecond)
 #_advanced

--- a/projects/redemption_configs/configs_specs/configs/specs/config_spec.hpp
+++ b/projects/redemption_configs/configs_specs/configs/specs/config_spec.hpp
@@ -524,7 +524,14 @@ void config_spec_definition(Writer && W)
         W.member(no_ini_no_gui, rdp_connpolicy, L, type_<RdpModeConsole>(), "mode_console", set(RdpModeConsole::allow), desc{"Console mode management for targets on Windows Server 2003 (requested with /console or /admin mstsc option)"});
 
         W.member(hidden_in_gui, rdp_connpolicy | advanced_in_connpolicy, L, type_<bool>(), "auto_reconnection_on_losing_target_link", set(false));
-    });
+
+        W.member(hidden_in_gui, rdp_connpolicy | advanced_in_connpolicy, L, type_<bool>(), "forward_client_build_number",
+            desc{
+                "Forward the build number advertised by the client to the server. "
+                "If forwarding is disabled a default (static) build number will be sent to the server."
+            },
+            set(true));
+        });
 
     W.section("metrics", [&]
     {

--- a/projects/redemption_configs/tests/test_config.cpp
+++ b/projects/redemption_configs/tests/test_config.cpp
@@ -265,9 +265,6 @@ RED_AUTO_TEST_CASE(TestConfigDefaultEmpty)
 
     RED_CHECK_EQUAL("",                               ini.get<cfg::context::rejected>());
 
-    RED_CHECK_EQUAL(false,                            ini.get<cfg::context::authenticated>());
-
-
     RED_CHECK_EQUAL(false,                            ini.is_asked<cfg::context::keepalive>());
 
     RED_CHECK_EQUAL(false,                            ini.get<cfg::context::keepalive>());

--- a/src/acl/module_manager/create_module_rdp.cpp
+++ b/src/acl/module_manager/create_module_rdp.cpp
@@ -736,6 +736,7 @@ ModPack create_mod_rdp(
 
     mod_rdp_params.enable_restricted_admin_mode = ini.get<cfg::mod_rdp::enable_restricted_admin_mode>();
     mod_rdp_params.file_system_params.smartcard_passthrough        = smartcard_passthrough;
+    mod_rdp_params.forward_client_build_number = ini.get<cfg::mod_rdp::forward_client_build_number>();
 
     mod_rdp_params.session_probe_params.alternate_directory_environment_variable = ini.get<cfg::mod_rdp::session_probe_alternate_directory_environment_variable>();
     enum {

--- a/src/mod/rdp/rdp_negociation.cpp
+++ b/src/mod/rdp/rdp_negociation.cpp
@@ -262,6 +262,8 @@ RdpNegociation::RdpNegociation(
     , license_client_name(info.hostname)
     , license_store(license_store)
     , use_license_store(mod_rdp_params.use_license_store)
+    , build_number(info.build)
+    , forward_build_number(mod_rdp_params.forward_client_build_number)
 {
     this->negociation_result.front_width = info.screen_info.width;
     this->negociation_result.front_width -= this->negociation_result.front_width % 4;
@@ -852,6 +854,11 @@ void RdpNegociation::send_connectInitialPDUwithGccConferenceCreateRequest()
                 cs_core.clientName[i] = byte_ptr(hostname)[i];
             }
             memset(&(cs_core.clientName[maxhostlen]), 0, (16 - maxhostlen) * sizeof(uint16_t));
+
+            /// Note: forwarding may be required for correct smartcard support; see issue #27767.
+            if (this->forward_build_number) {
+                cs_core.clientBuild = this->build_number;
+            }
 
             if (this->nego.tls){
                 cs_core.serverSelectedProtocol = this->nego.selected_protocol;

--- a/src/mod/rdp/rdp_negociation.hpp
+++ b/src/mod/rdp/rdp_negociation.hpp
@@ -186,6 +186,17 @@ private:
     LicenseApi& license_store;
     const bool use_license_store;
 
+    /// Client build number.
+    /// Represents the 'clientBuild' field of Client Core Data (TS_UD_CS_CORE)
+    /// as specified in [MS-RDPBCGR] §2.2.1.3.2.
+    /// Note: must be forwarded from client to server 
+    /// for correct smartcard support; see issue #27767.
+    const uint32_t build_number;
+
+    /// Indicates whether to forward the client build number to the server.
+    /// If set to 'false' the default (static) build number will be used.
+    const bool forward_build_number;
+
 public:
     RdpNegociation(
         const ChannelsAuthorizations channels_authorizations,

--- a/src/mod/rdp/rdp_params.hpp
+++ b/src/mod/rdp/rdp_params.hpp
@@ -210,6 +210,9 @@ struct ModRDPParams
     RDPVerbose verbose;
     BmpCache::Verbose cache_verbose = BmpCache::Verbose::none;
 
+    /// Note: may be required for correct smartcard support; see issue #27767.
+    bool forward_client_build_number = true;
+
     ModRDPParams( const char * target_user
                 , const char * target_password
                 , const char * target_host

--- a/tests/acl/test_license_api.cpp
+++ b/tests/acl/test_license_api.cpp
@@ -53,6 +53,7 @@
 RED_AUTO_TEST_CASE(TestWithoutExistingLicense)
 {
     ClientInfo info;
+    info.build                 = 2600;
     info.keylayout             = 0x040C;
     info.console_session       = false;
     info.brush_cache_code      = 0;
@@ -354,6 +355,7 @@ RED_AUTO_TEST_CASE(TestWithoutExistingLicense)
 RED_AUTO_TEST_CASE(TestWithExistingLicense)
 {
     ClientInfo info;
+    info.build                 = 2600;
     info.keylayout             = 0x040C;
     info.console_session       = false;
     info.brush_cache_code      = 0;

--- a/tests/client_mods/test_rdp_client_large_pointer.cpp
+++ b/tests/client_mods/test_rdp_client_large_pointer.cpp
@@ -61,6 +61,7 @@ RED_AUTO_TEST_CASE(TestRdpClientLargePointerDisabled)
     //SocketTransport::Verbose STVerbose = SocketTransport::Verbose::dump;
 
     ClientInfo info;
+    info.build                 = 2600;
     info.keylayout             = 0x040C;
     info.console_session       = false;
     info.brush_cache_code      = 0;
@@ -184,6 +185,7 @@ RED_AUTO_TEST_CASE(TestRdpClientLargePointerEnabled)
     //SocketTransport::Verbose STVerbose = SocketTransport::Verbose::dump;
 
     ClientInfo info;
+    info.build                 = 2600;
     info.keylayout             = 0x040C;
     info.console_session       = false;
     info.brush_cache_code      = 0;

--- a/tests/client_mods/test_rdp_client_tls_w2008.cpp
+++ b/tests/client_mods/test_rdp_client_tls_w2008.cpp
@@ -50,6 +50,7 @@ using namespace std::chrono_literals;
 RED_AUTO_TEST_CASE(TestDecodePacket)
 {
     ClientInfo info;
+    info.build                 = 2600;
     info.keylayout             = 0x040C;
     info.console_session       = false;
     info.brush_cache_code      = 0;
@@ -173,6 +174,7 @@ RED_AUTO_TEST_CASE(TestDecodePacket)
 RED_AUTO_TEST_CASE(TestDecodePacket2)
 {
     ClientInfo info;
+    info.build                 = 2600;
     info.keylayout             = 0x040C;
     info.console_session       = false;
     info.brush_cache_code      = 0;

--- a/tests/client_mods/test_rdp_client_wab.cpp
+++ b/tests/client_mods/test_rdp_client_wab.cpp
@@ -48,6 +48,7 @@
 RED_AUTO_TEST_CASE(TestDecodePacket)
 {
     ClientInfo info;
+    info.build                 = 2600;
     info.keylayout             = 0x040C;
     info.console_session       = false;
     info.brush_cache_code      = 0;

--- a/tests/mod/rdp/test_rdp.cpp
+++ b/tests/mod/rdp/test_rdp.cpp
@@ -62,6 +62,7 @@ RED_AUTO_TEST_CASE(TestModRDPWin2008Server)
     //SocketTransport::Verbose STVerbose = SocketTransport::Verbose::dump;
 
     ClientInfo info;
+    info.build = 2600;
     info.keylayout = 0x04C;
     info.console_session = false;
     info.brush_cache_code = 0;

--- a/tools/sesman/sesmanworker/sesmanconnpolicyspec.py
+++ b/tools/sesman/sesmanworker/sesmanconnpolicyspec.py
@@ -78,6 +78,9 @@ cp_spec = {
         u'mod_rdp:auto_reconnection_on_losing_target_link': (
             'auto_reconnection_on_losing_target_link', False
         ),
+        u'mod_rdp:forward_client_build_number': (
+            'forward_client_build_number', True
+        ),
         u'context:rail_disconnect_message_delay': (
             'remote_programs_disconnect_message_delay', 3000
         ),


### PR DESCRIPTION
Allow the client build number to be transferred to the server during RDP negociation.