### PR TITLE
Interactive target module display target_host when target_device is empty

### DIFF
--- a/src/mod/internal/interactive_target_mod.cpp
+++ b/src/mod/internal/interactive_target_mod.cpp
@@ -40,7 +40,10 @@ InteractiveTargetMod::InteractiveTargetMod(
         this->ask_device, this->ask_login, this->ask_password,
         theme,
         TR(trkeys::target_info_required, language(vars)),
-        TR(trkeys::device, language(vars)), vars.get<cfg::globals::target_device>().c_str(),
+        TR(trkeys::device, language(vars)),
+        vars.get<cfg::globals::target_device>().empty()
+        ? vars.get<cfg::context::target_host>().c_str()
+        : vars.get<cfg::globals::target_device>().c_str(),
         TR(trkeys::login, language(vars)), vars.get<cfg::globals::target_user>().c_str(),
         TR(trkeys::password, language(vars)),
         font, &this->language_button)

--- a/src/mod/internal/interactive_target_mod.hpp
+++ b/src/mod/internal/interactive_target_mod.hpp
@@ -31,7 +31,7 @@
 using InteractiveTargetModVariables = vcfg::variables<
     vcfg::var<cfg::globals::target_user,                vcfg::accessmode::is_asked | vcfg::accessmode::set | vcfg::accessmode::get>,
     vcfg::var<cfg::context::target_password,            vcfg::accessmode::is_asked | vcfg::accessmode::set>,
-    vcfg::var<cfg::context::target_host,                vcfg::accessmode::is_asked | vcfg::accessmode::set>,
+    vcfg::var<cfg::context::target_host,                vcfg::accessmode::is_asked | vcfg::accessmode::set | vcfg::accessmode::get>,
     vcfg::var<cfg::globals::target_device,              vcfg::accessmode::get>,
     vcfg::var<cfg::context::display_message,            vcfg::accessmode::set>,
     vcfg::var<cfg::translation::language,               vcfg::accessmode::get>,


### PR DESCRIPTION
@jukeks Proposal for #70 
If `target_device` is empty and `target_host` is not, then `target_host` is not asked and we can display `target_host` in the device field
