### PR TITLE
Fix missing disconnection event with Rail mod

### DIFF
--- a/src/mod/internal/rail_module_host_mod.cpp
+++ b/src/mod/internal/rail_module_host_mod.cpp
@@ -114,6 +114,11 @@ bool RailModuleHostMod::server_error_encountered() const
     return this->module_host.get_managed_mod().server_error_encountered();
 }
 
+void RailModuleHostMod::disconnect()
+{
+    return this->module_host.get_managed_mod().disconnect();
+}
+
 void RailModuleHostMod::move_size_widget(int16_t left, int16_t top, uint16_t width,
                         uint16_t height)
 {

--- a/src/mod/internal/rail_module_host_mod.cpp
+++ b/src/mod/internal/rail_module_host_mod.cpp
@@ -116,7 +116,7 @@ bool RailModuleHostMod::server_error_encountered() const
 
 void RailModuleHostMod::disconnect()
 {
-    return this->module_host.get_managed_mod().disconnect();
+    this->module_host.get_managed_mod().disconnect();
 }
 
 void RailModuleHostMod::move_size_widget(int16_t left, int16_t top, uint16_t width,

--- a/src/mod/internal/rail_module_host_mod.hpp
+++ b/src/mod/internal/rail_module_host_mod.hpp
@@ -68,6 +68,8 @@ public:
 
     bool server_error_encountered() const override;
 
+    void disconnect() override;
+
     void move_size_widget(int16_t left, int16_t top, uint16_t width,
                           uint16_t height) override;
 


### PR DESCRIPTION
When RDP connection is wrapped with Rail mod redemption misses disconnection event in session logs. That happens due to the fact, that RailModuleHostMod wrapper does not resend disconnection event to managed mod. This PR fixes that.